### PR TITLE
add guidelines for evaluations

### DIFF
--- a/0000-evidence-template.md
+++ b/0000-evidence-template.md
@@ -23,23 +23,16 @@
 
 
 ## Evidence
-*Indicate your contributions in relation to Polkadot SDK.*
+*Explain why your contributions in relation to the Polkadot SDK are worthy of retention/promotion. Refer to the terms of the [Manifesto](https://github.com/polkadot-fellows/manifesto/blob/main/manifesto.pdf) and provide links to relevant content (i.e code, articles, media, etc.) to show that you are meeting all the requirements.*
 
-|  Areas of Contribution | Tasks  | Links   |Notes   |
-|---|---|---|---|
-|Polkadot SDK   | Specification & Implementation of Multi Block Migrations   | [RFC 13](https://github.com/polkadot-fellows/RFCs/pull/13) & [SDK 1781](https://github.com/paritytech/polkadot-sdk/pull/1781)  | *This is a 1st example.*  |
-|Roadmap/Vision   | Specification and implementation of Multi-Asset Sub-Treasuries  | [Forum post](https://forum.polkadot.network/t/collective-based-multi-asset-treasuries/2899) & delivery of a [Polkadot Treasury acquisition of USDT and USDC](https://polkadot.subsquare.io/referenda/457), and a [Fellowship sub-treasury and Fellowship Salary account funding with USDT](https://collectives.subsquare.io/fellowship/salary). |  *This is a 2nd example.* |
-|   |   |   |   |
-|   |   |   |   |
-|   |   |   |   |
 
 
 ## Voting record
-*Provide your voting record in relation to required thresholds.* 
+*Provide your voting record in relation to required thresholds for your rank.* 
 
 |  Ranks | Activity thresholds | Agreement thresholds | Member's voting activities | Comments |
 |---|---|---|---|---|
-|III|70%   |100%  |I have voted on ?? out of ?? referenda in which I was eligible to vote (i.e ?? % voting activity). Out of ?? referenda in which members of higher ranks were in complete agreement, I have voted in line with the consensus ?? times (i.e ?? % voting agreement).  |*This is an example.* |
+|III|70%   |100%  |I have voted on x out of xx referenda in which I was eligible to vote (i.e xx % voting activity). Out of xx referenda in which members of higher ranks were in complete agreement, I have voted in line with the consensus x times (i.e xx % voting agreement).  |*This is an example.* |
 |I  |90%   |N/A   |   |  |
 |II |80%   |N/A   |   |  |
 |III|70%   |100%  |   |  |

--- a/0000-evidence-template.md
+++ b/0000-evidence-template.md
@@ -23,7 +23,7 @@
 
 
 ## Evidence
-*Explain why your contributions in relation to the Polkadot SDK are worthy of retention/promotion. Refer to the terms of the [Manifesto](https://github.com/polkadot-fellows/manifesto/blob/main/manifesto.pdf) and provide links to relevant content (i.e code, articles, media, etc.) to show that you are meeting all the requirements.*
+*Explain why your contributions in relation to the Polkadot SDK are worthy of retention/promotion. Refer to the terms in Section 6 of the [Manifesto](https://github.com/polkadot-fellows/manifesto/blob/main/manifesto.pdf) and provide links to relevant content (i.e code, articles, media, etc.) to show that you are meeting all the requirements.*
 
 
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Evidences are a proof of work to indicate the Fellowship's commitment to impleme
 
 All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their evidence report once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
 
-Evidences should:
-- describe why the work done is of sufficient quality and depth that it should be considered relevant for retention at the current rank.
-- explain what the member has learned during months of active protocol development.
-- connect the work done to the Manifesto and its requirements.
+**Evidences should:**
+- **describe why the work done is of sufficient quality and depth that it should be considered relevant for retention at the current rank.**
+- **explain what the member has learned during months of active protocol development.**
+- **connect the work done to the Manifesto and its requirements.**
 
 All members seeking retentions or promotions will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in the Manifesto. 
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,16 @@ Evidences are scoped to the subset of these concerns which must be held consiste
 
 Evidences are a proof of work to indicate the Fellowship's commitment to implement and maintain designs and architectures for Polkadot (Main) Network, as well as participate in discussion and social consensus according to open-source principles.
 
-All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their evidences once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
+All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their evidence report once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
 
-All members (Ranks I-VI) must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members.
+Evidences should:
+- describe why the work done is of sufficient quality and depth that it should be considered relevant for retention at the current rank.
+- explain what the member has learned during months of active protocol development.
+- connect the work done to the Manifesto and its requirements.
 
 All members seeking retentions or promotions will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in the Manifesto. 
+
+All members (Ranks I-VI) must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members.
 
 Members seeking promotions for Rank III-VI are required to attend an **in-person interview** before their request can be moved to on-chain voting. The Fellowship Sub-Treasury can cover all costs incurred while attending these in-person evaluations. 
 
@@ -69,7 +74,7 @@ To submit an Evidence, follow these steps:
   * Create a new folder in the `evidence` folder and rename it to match your Github username.
   * Copy the `0000-evidence-template.md` file into the new folder and rename it to match the title of your request.
   * Fill out the Evidence template and open a PR.
-  * Announce the evidence to the Fellowship and wait at least one week.
+  * Announce the evidence to the Fellowship and wait at least one week for the PR to be reviewed.
   * If there are no major pushbacks by the Fellowship, submit the evidence on-chain via the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare.
 
 Once the request has been approved via on-chain referendum, the PR can be merged. This on-chain process is designed to be resilient to where the Evidences are hosted and in what format, so it can be migrated away from GitHub in the future. The Fellowship should not approve more than one Evidence with the same number. PRs may be closed by their author, when sufficiently stale, or after a period of 6 months without approval. 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Evidences are scoped to the subset of these concerns which must be held consiste
 
 Evidences are a proof of work to indicate the Fellowship's commitment to implement and maintain designs and architectures for Polkadot (Main) Network, as well as participate in discussion and social consensus according to open-source principles.
 
-All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their Evidences once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
+All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their evidences once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
 
 All members (Ranks I-VI) must serve a minimum period of service of 12 months at their current rank before seeking promotion to a higher rank. There is no minimum period of service for Candidates seeking to become members.
 
-All Members seeking retentions or promotions will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in the Manifesto. 
+All members seeking retentions or promotions will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in the Manifesto. 
 
 Members seeking promotions for Rank III-VI are required to attend an **in-person interview** before their request can be moved to on-chain voting. The Fellowship Sub-Treasury can cover all costs incurred while attending these in-person evaluations. 
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To submit an Evidence, follow these steps:
   * Create a new folder in the `evidence` folder and rename it to match your Github username.
   * Copy the `0000-evidence-template.md` file into the new folder and rename it to match the title of your request.
   * Fill out the Evidence template and open a PR.
-  * Announce the evidence to the Fellowship and wait at least one week for the PR to be reviewed.
+  * Announce the evidence to the Fellowship and wait at least one week.
   * If there are no major pushbacks by the Fellowship, submit the evidence on-chain via the [Core Fellowship UI](https://collectives.subsquare.io/fellowship/core) provided by Subsquare.
 
 Once the request has been approved via on-chain referendum, the PR can be merged. This on-chain process is designed to be resilient to where the Evidences are hosted and in what format, so it can be migrated away from GitHub in the future. The Fellowship should not approve more than one Evidence with the same number. PRs may be closed by their author, when sufficiently stale, or after a period of 6 months without approval. 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Evidences are scoped to the subset of these concerns which must be held consiste
 
 Evidences are a proof of work to indicate the Fellowship's commitment to implement and maintain designs and architectures for Polkadot (Main) Network, as well as participate in discussion and social consensus according to open-source principles.
 
-All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their evidence report once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
+All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their Evidences once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
 
 **Evidences should:**
 - **describe why the work done is of sufficient quality and depth that it should be considered relevant for retention/promotion.**

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Evidences are a proof of work to indicate the Fellowship's commitment to impleme
 All members that have been inducted for standard allowance as per the [Fellowship Salaries](https://github.com/polkadot-fellows/RFCs/blob/main/text/0050-fellowship-salaries.md) must submit their evidence report once over a period of time (3 months for Rank I-II, 6 months for Rank III-VI) to avoid demotion to a lower rank. 
 
 **Evidences should:**
-- **describe why the work done is of sufficient quality and depth that it should be considered relevant for retention at the current rank.**
-- **explain what the member has learned during months of active protocol development.**
+- **describe why the work done is of sufficient quality and depth that it should be considered relevant for retention/promotion.**
+- **explain what the member has learned during the past months of active protocol development.**
 - **connect the work done to the Manifesto and its requirements.**
 
 All members seeking retentions or promotions will need to reflect on their voting record in relation to the thresholds for voting "activity" and voting "agreement" described in the Manifesto. 


### PR DESCRIPTION
This PR updates the docs with:
- generic guidelines for writing evidences (to be used by members)
- recommendations for assessing the quality of evidence reports (to be used by rank evaluators)