### PR TITLE
[2024-Q3] ank4n: retain rank I

### DIFF
--- a/evidence/ank4n/0002-2024-Q3.md
+++ b/evidence/ank4n/0002-2024-Q3.md
@@ -1,0 +1,44 @@
+# Evidence-0002: Retention at Rank I
+
+|                 |              |
+| --------------- |--------------|
+| **Report Date** | 2024/10/02   |
+| **Submitted by**| Ankan Anurag |
+
+## Member details
+
+- Matrix username: `@ankan:parity.io`
+- Polkadot address: `16aQgRVKfD22NehdzZD2VPoenP2hvx8RS2gUirfk6abiCies`
+- Current rank: 1
+- Date of initial induction: 2023/11/11
+- Date of last report: 2024/06/28
+- Area(s) of Expertise/Interest: `Staking`
+
+## Reporting period
+
+- Start date: 2024/06/28
+- End date: 2024/09/30
+
+
+## Evidence
+Continuing from my previous [evidence](https://github.com/Ank4n/Evidences/blob/805002ec11b8b349c0381d950467219a93af132f/evidence/ank4n/0001-ank4n-2024-H1.md), my primary focus has been to [enable nomination pool members to participate in OpenGov](https://support.polkadot.network/support/solutions/articles/65000188140). While this is already live on westend, it was pending audits before it can be enabled in production. Since then, I have addressed various improvements and fixes raised during the audit process. These changes are included in the [polkadot-sdk/stable2409](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-stable2409) release and once [Polkadot's runtime is upgraded to this version](https://github.com/polkadot-fellows/runtimes/issues/455), over [24M DOTs](https://apps.turboflakes.io/?chain=polkadot#/pools) owned by members of the pool will be eligible to participate in voting.
+
+PR list: [#4822](https://github.com/paritytech/polkadot-sdk/pull/4822), [#4804](https://github.com/paritytech/polkadot-sdk/pull/4904), [#4981](https://github.com/paritytech/polkadot-sdk/pull/4981), [#4998](https://github.com/paritytech/polkadot-sdk/pull/4998), [#4999](https://github.com/paritytech/polkadot-sdk/pull/4999).
+
+However, these changes have the unintended consequence that a [direct staker will not be able to participate in the pool anymore](https://hackmd.io/@ak0n/delegate-stake-faq#Dual-staking). The root cause is that `pallet-staking` uses [locks](https://paritytech.github.io/polkadot-sdk/master/frame_support/traits/tokens/currency/trait.LockableCurrency.html) (similar to [freeze](https://paritytech.github.io/polkadot-sdk/master/frame_support/traits/tokens/fungible/freeze/index.html) in the deprecated [Currency](https://paritytech.github.io/polkadot-sdk/master/frame_support/traits/tokens/currency/index.html) trait) instead of [holds](https://paritytech.github.io/polkadot-sdk/master/frame_support/traits/tokens/fungible/hold/index.html). This is largely due to legacy code, and `pallet-staking` should ideally use `holds`. I also have a [working PR](https://github.com/paritytech/polkadot-sdk/pull/5501) to address this issue, which is currently awaiting review and audit.
+
+## Voting record
+*Provide your voting record in relation to required thresholds for your rank.*
+
+|  Ranks | Activity thresholds | Agreement thresholds | Member's voting activities | Comments |
+|---|---|---|---|---|
+|I  |90%   |N/A   | I have voted on 0 out of 1 referenda in the eligible period.  |  |
+
+
+## Misc
+
+- [ ] Question(s):
+
+- [ ] Concern(s):
+
+- [ ] Comment(s): 


### PR DESCRIPTION
Evidence to retain rank I.
Reporting period: 28th June 2024 to 30th September 2024.

[IPFS link](https://subsquare.infura-ipfs.io/ipfs/bafybeib7722bbaapr6gvrpxcjtlwb5xkocu7gxisyf2ontfojwk2kzi2r4). 
Better viewed at [rendered link](https://github.com/Ank4n/Evidences/blob/9f19d71e7374fe982ef2e75189b609e918d8a127/evidence/ank4n/0002-2024-Q3.md).
