### PR TITLE
add link to previous report

### DIFF
--- a/0000-argument-template.md
+++ b/0000-argument-template.md
@@ -12,7 +12,8 @@
 - Polkadot address: 
 - Current rank: 
 - Date of initial induction:
-- Date of last report: 
+- Date of last report:
+- Link to last report: https://github.com/polkadot-fellows/Evaluations/pull/XXX
 - Area(s) of Expertise/Interest: 
 
 

--- a/0000-argument-template.md
+++ b/0000-argument-template.md
@@ -13,7 +13,7 @@
 - Current rank: 
 - Date of initial induction:
 - Date of last report:
-- Link to last report: https://github.com/polkadot-fellows/Evaluations/pull/XXX
+- Link to last report: 
 - Area(s) of Expertise/Interest: 
 
 


### PR DESCRIPTION
This PR updates the argument template to include a section whereby members can share a link to their previous retention/promotion argument.

This is to:
- help Members keep a clear trail of their contributions and demonstrate growth from one reporting period to the next
- help Fellows check that Members' contributions are relevant and gaining traction over time